### PR TITLE
Hopper Event

### DIFF
--- a/ChestsPlusPlus_Main/src/main/java/com/jamesdpeters/minecraft/chests/listeners/HopperListener.java
+++ b/ChestsPlusPlus_Main/src/main/java/com/jamesdpeters/minecraft/chests/listeners/HopperListener.java
@@ -35,6 +35,8 @@ public class HopperListener implements Listener {
         //TO HOPPER
         if(event.getDestination().getHolder() instanceof Hopper){
             if(event.getDestination().getLocation() != null){
+                // If the event is cancelled by other plugin
+                if(event.isCancelled()) return;
                 if(event.getDestination().getLocation().getBlock().isBlockPowered()) return;
             }
             event.setCancelled(!HopperFilter.isInFilter(event.getDestination().getLocation().getBlock(),event.getItem()));


### PR DESCRIPTION
Check if the event is cancelled by other plugin such as ChestShop, QuickShop, etc.